### PR TITLE
Don't include development libs when building for production

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -75,6 +75,7 @@ module.exports = yeoman.generators.Base.extend({
       );
       this._copyTpl('README.md' ,'README.md');
       this._copyTpl('webpack.config.js', 'webpack.config.js');
+      this._copyTpl('webpack.production.js', 'webpack.production.js');
       this._copyTpl('server.js', 'server.js');
       this._copyTpl('index.html', 'index.html');
       this._copyTpl('js/index.js', 'js/index.js');

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -6,6 +6,7 @@
   },
   "scripts": {
     "start": "DEBUG=true node server.js",
-    "build": "webpack -p"
+    "build": "webpack -p --config webpack.production.js",
+    "build-dev": "webpack -p"
   }
 }

--- a/generators/app/templates/webpack.production.js
+++ b/generators/app/templates/webpack.production.js
@@ -1,0 +1,31 @@
+var webpack = require('webpack');
+var ExtractTextPlugin = require('extract-text-webpack-plugin');
+
+var devFlagPlugin = new webpack.DefinePlugin({
+  __DEV__: JSON.stringify(JSON.parse(process.env.DEBUG || 'false'))
+});
+
+module.exports = {
+  entry: [
+    './js/index.js'
+  ],
+  output: {
+    path: __dirname + '/static/',
+    publicPath: '/static/',
+    filename: 'bundle.js',
+  },
+  plugins: [
+    new webpack.NoErrorsPlugin(),
+    devFlagPlugin,
+    new ExtractTextPlugin('app.css')
+  ],
+  module: {
+    loaders: [
+      { test: /\.js$/, loaders: ['babel'], exclude: /node_modules/ },
+      { test: /\.css$/, loader: ExtractTextPlugin.extract('css-loader?module!cssnext-loader') }
+    ]
+  },
+  resolve: {
+    extensions: ['', '.js', '.json']
+  }
+};


### PR DESCRIPTION
Add a production webpack config and use it for the `build` script.  Add
an additional script `build-dev` for building static assets that include
the hot-loader.

Fixes #9
