### PR TITLE
[Resolves #10] Fresh installs have a Uncaught TypeError when using 'npm start'

### DIFF
--- a/generators/app/templates/js/store/configureStore.js
+++ b/generators/app/templates/js/store/configureStore.js
@@ -1,12 +1,12 @@
 import {createStore, applyMiddleware, combineReducers, compose} from 'redux';
 import thunkMiddleware from 'redux-thunk';
+import {devTools, persistState} from 'redux-devtools';
 import * as reducers from '../reducers/index';
 
 let createStoreWithMiddleware;
 
 // Configure the dev tools when in DEV mode
 if (__DEV__) {
-  const {devTools, persistState} = require('redux-devtools');
   createStoreWithMiddleware = compose(
     applyMiddleware(thunkMiddleware),
     devTools(),

--- a/test/test-app.js
+++ b/test/test-app.js
@@ -18,7 +18,19 @@ describe('redux:app', function () {
       'bower.json',
       'package.json',
       '.editorconfig',
-      '.jshintrc'
+      'index.html'
     ]);
+  });
+
+  it('create proper configStore file', function() {
+    var store = './js/store/configureStore.js';
+    assert.file(store);
+    assert.fileContent(store, "import {createStore, applyMiddleware, combineReducers, compose} from 'redux';");
+    assert.fileContent(store, "if (__DEV__) {");
+    assert.fileContent(store, "createStoreWithMiddleware = compose(");
+    assert.fileContent(store, "applyMiddleware(thunkMiddleware),");
+    assert.fileContent(store, "devTools()");
+    assert.fileContent(store, "persistState(window.location.href.match(/[?&]debug_session=([^&]+)\\b/))");
+    assert.fileContent(store, ")(createStore);");
   });
 });


### PR DESCRIPTION
Updated configure store to use new redux-devtools configuration.  Fixes problem of 'Uncaught TypeError: store.getState is not a function'

It would work using `node server.js` but with running `npm start` or `DEBUG=true npm start` the app was failing.  Updating the store configuration [using their readme](https://github.com/gaearon/redux-devtools#installation) seemed to fix it for me locally.  

I'm very skeptical as to why moving it from a require to an import actually fixed the problem.  Don't know enough about Node/ES6 yet to know why though...

When the generator runs on a fresh install this is what the configureStore.js looks like:

```
import {createStore, applyMiddleware, combineReducers, compose} from 'redux';
import thunkMiddleware from 'redux-thunk';
import * as reducers from '../reducers/index';

let createStoreWithMiddleware;

// Configure the dev tools when in DEV mode
if (__DEV__) {
  let {devTools, persistState} = require('redux-devtools');
  createStoreWithMiddleware = compose(
    applyMiddleware(thunkMiddleware),
    devTools(),
    persistState(window.location.href.match(/[?&]debug_session=([^&]+)\b/)),
    createStore
  );
} else {
  createStoreWithMiddleware = applyMiddleware(thunkMiddleware)(createStore);
}

const rootReducer = combineReducers(reducers);

export default function configureStore(initialState) {
  return createStoreWithMiddleware(rootReducer, initialState);
}
```

Seems like the real issue is it's just not applying the template properly.  Its adding createStore as an argument to compose which is just wrong.
