### PR TITLE
Fix issue with both Babel 5 and 6 being installed by locking version of Babel to 5

### DIFF
--- a/generators/app/index.babel.js
+++ b/generators/app/index.babel.js
@@ -94,7 +94,7 @@ export default Base.extend({
       this.getPackageVersions(
         'deps',
         [
-          ['babel-core', '5.0.33'],
+          ['babel-core', '5.8.33'],
           'es6-promise',
           'whatwg-fetch',
           'lodash',

--- a/generators/app/index.babel.js
+++ b/generators/app/index.babel.js
@@ -94,7 +94,7 @@ export default Base.extend({
       this.getPackageVersions(
         'deps',
         [
-          'babel-core',
+          ['babel-core', '5.0.33']
           'es6-promise',
           'whatwg-fetch',
           'lodash',

--- a/generators/app/index.babel.js
+++ b/generators/app/index.babel.js
@@ -94,7 +94,7 @@ export default Base.extend({
       this.getPackageVersions(
         'deps',
         [
-          ['babel-core', '5.0.33']
+          ['babel-core', '5.0.33'],
           'es6-promise',
           'whatwg-fetch',
           'lodash',

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -116,11 +116,11 @@ exports['default'] = _yeomanGenerator.Base.extend({
 
   configuring: {
     deps: function deps() {
-      this.getPackageVersions('deps', [['babel-core', '5.0.33'], 'es6-promise', 'whatwg-fetch', 'lodash', ['react', '0.14.0'], ['react-dom', '0.14.0'], ['redux', '3.0.4'], ['react-redux', '4.0.0'], ['redux-devtools', '2.1.5'], ['redux-thunk', '1.0.0']]);
+      this.getPackageVersions('deps', [['babel-core', '5.8.33'], 'es6-promise', 'whatwg-fetch', 'lodash', ['react', '0.14.0'], ['react-dom', '0.14.0'], ['redux', '3.0.4'], ['react-redux', '4.0.0'], ['redux-devtools', '2.1.5'], ['redux-thunk', '1.0.0']]);
     },
 
     devDeps: function devDeps() {
-      this.getPackageVersions('devDeps', ['webpack', 'webpack-dev-server', 'css-loader', ['babel-core', '5.0.33'], 'babel-loader', 'react-hot-loader', 'style-loader', 'extract-text-webpack-plugin', 'cssnext-loader']);
+      this.getPackageVersions('devDeps', ['webpack', 'webpack-dev-server', 'css-loader', ['babel-core', '5.8.33'], 'babel-loader', 'react-hot-loader', 'style-loader', 'extract-text-webpack-plugin', 'cssnext-loader']);
     }
   },
 

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -116,11 +116,11 @@ exports['default'] = _yeomanGenerator.Base.extend({
 
   configuring: {
     deps: function deps() {
-      this.getPackageVersions('deps', ['babel-core', 'es6-promise', 'whatwg-fetch', 'lodash', ['react', '0.14.0'], ['react-dom', '0.14.0'], ['redux', '3.0.4'], ['react-redux', '4.0.0'], ['redux-devtools', '2.1.5'], ['redux-thunk', '1.0.0']]);
+      this.getPackageVersions('deps', [['babel-core', '5.0.33'], 'es6-promise', 'whatwg-fetch', 'lodash', ['react', '0.14.0'], ['react-dom', '0.14.0'], ['redux', '3.0.4'], ['react-redux', '4.0.0'], ['redux-devtools', '2.1.5'], ['redux-thunk', '1.0.0']]);
     },
 
     devDeps: function devDeps() {
-      this.getPackageVersions('devDeps', ['webpack', 'webpack-dev-server', 'css-loader', 'babel-core', 'babel-loader', 'react-hot-loader', 'style-loader', 'extract-text-webpack-plugin', 'cssnext-loader']);
+      this.getPackageVersions('devDeps', ['webpack', 'webpack-dev-server', 'css-loader', ['babel-core', '5.0.33'], 'babel-loader', 'react-hot-loader', 'style-loader', 'extract-text-webpack-plugin', 'cssnext-loader']);
     }
   },
 


### PR DESCRIPTION
Until other packages can be upgrade.

Fixes issue seen in #23 after 0.3.0 upgrade.
