### PR TITLE
fix: Unhandled 'error' event derails project generation

### DIFF
--- a/generators/app/index.babel.js
+++ b/generators/app/index.babel.js
@@ -42,7 +42,7 @@ function copy(src, dest) {
 }
 
 export default Base.extend({
-  init() {
+  initializing() {
     this.copy = copy.bind(this);
     this.getPackageVersions = getPackageVersions.bind(this);
   },

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -76,7 +76,7 @@ function copy(src, dest) {
 }
 
 exports['default'] = _yeomanGenerator.Base.extend({
-  init: function init() {
+  initializing: function initializing() {
     this.copy = copy.bind(this);
     this.getPackageVersions = getPackageVersions.bind(this);
   },


### PR DESCRIPTION
Issue: #32 
- yo version: 1.5.0
- node version: 5.1.0

```
events.js:141
      throw er; // Unhandled 'error' event
      ^

TypeError: this.getPackageVersions is not a function
    at deps (C:\Users\kamijin-fanta\AppData\Roaming\npm\node_modules\generator-redux\
generators\app\index.js:121:12)
    at C:\Users\kamijin-fanta\AppData\Roaming\npm\node_modules\generator-redux\node_m
odules\yeoman-generator\lib\base.js:429:16
    at processImmediate [as _immediateCallback] (timers.js:383:17)
```

reference for: https://github.com/yeoman/generator-generator/blob/d9d604e97b593dabe5f7ba763ae8ff7f73bfd4aa/app/index.js#L16
