### PR TITLE
Use `cross-env` to support Windows environments on `npm start`

### DIFF
--- a/generators/app/index.babel.js
+++ b/generators/app/index.babel.js
@@ -135,7 +135,9 @@ export default Base.extend({
           'redbox-react',
           'style-loader',
           'extract-text-webpack-plugin',
-          'cssnext-loader'
+          'cssnext-loader',
+          'cross-env',
+          ['webpack-sources', '0.1.0']
         ]
       );
     }
@@ -177,4 +179,3 @@ export default Base.extend({
   }
 
 });
-

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -130,7 +130,7 @@ exports['default'] = _yeomanGenerator.Base.extend({
     },
 
     devDeps: function devDeps() {
-      this.getPackageVersions('devDeps', ['webpack', 'webpack-dev-middleware', 'webpack-hot-middleware', 'css-loader', ['babel-core', '5.0.0'], ['babel-loader', '5.0.0'], 'babel-plugin-react-display-name', 'babel-plugin-react-transform', 'express', 'path', 'react-transform-catch-errors', 'react-transform-hmr', 'redbox-react', 'style-loader', 'extract-text-webpack-plugin', 'cssnext-loader']);
+      this.getPackageVersions('devDeps', ['webpack', 'webpack-dev-middleware', 'webpack-hot-middleware', 'css-loader', ['babel-core', '5.0.0'], ['babel-loader', '5.0.0'], 'babel-plugin-react-display-name', 'babel-plugin-react-transform', 'express', 'path', 'react-transform-catch-errors', 'react-transform-hmr', 'redbox-react', 'style-loader', 'extract-text-webpack-plugin', 'cssnext-loader', 'cross-env', ['webpack-sources', '0.1.0']]);
     }
   },
 

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -2,7 +2,7 @@
   "name": "<%= slug %>",
   "version": "0.1.0",
   "scripts": {
-    "start": "DEBUG=true node server.js",
+    "start": "cross-env DEBUG=true node server.js",
     "build": "webpack -p --config webpack.production.js",
     "build-dev": "webpack -p"
   },


### PR DESCRIPTION
Fixes #20
